### PR TITLE
Added hdr_render option in render() method to support HDR rendering with tone mapping

### DIFF
--- a/examples/example9.py
+++ b/examples/example9.py
@@ -1,0 +1,47 @@
+import sys
+sys.path.insert(0, '/Users/olakenjiforslund/OKF/Leisure/Programming/Python/projects/pygame-render/src/') 
+
+import pygame
+from pygame_render import RenderEngine
+import math
+
+pygame.init()
+display_size = (800, 600)
+
+engine = RenderEngine(display_size[0], display_size[1])
+screen = engine.make_layer(display_size)
+
+hdr_texture = engine.make_layer(display_size, dtype = 'f4')
+hdr_layer = engine.make_layer(display_size, dtype = 'f4')
+
+pygame.font.init()
+font = pygame.font.SysFont("Arial", 30)
+
+running = True
+time = 0
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+
+    time += 0.005
+    value = 5 * math.sin(time) + 5#0 - 10
+
+    screen.clear(0, 0, 0, 255)
+    hdr_texture.clear(255 * value, 255, 255, 255)
+
+    engine.render(hdr_texture.texture, hdr_layer)
+    engine.render(hdr_layer.texture, screen, hdr_render=True)
+
+    value_text = f"R value: {255 * value:.2f}"  # Format the value to 2 decimal places
+    text_surface = font.render(value_text, True, (255, 255, 255))  # White text
+    texture = engine.surface_to_texture(text_surface)
+    
+    engine.render(texture, screen)
+    texture.release()
+
+    engine.render(screen.texture, engine.screen)
+
+    pygame.display.flip()
+
+pygame.quit()

--- a/src/pygame_render/fragment_tone.glsl
+++ b/src/pygame_render/fragment_tone.glsl
@@ -1,0 +1,17 @@
+#version 330 core
+
+in vec2 fragmentTexCoord;// top-left is [0, 1] and bottom-right is [1, 0]
+uniform sampler2D imageTexture;// texture in location 0
+
+out vec4 FragColor;
+uniform float exposure = 0.1;
+
+vec3 toneMapping(vec3 color) {
+    return vec3(1) - exp(-color*exposure);
+}
+
+void main() {    
+    vec3 hdrColor = texture(imageTexture, fragmentTexCoord).rgb;    
+    vec3 ldrColor = toneMapping(hdrColor);    
+    FragColor = vec4(ldrColor, 1.0);
+}

--- a/src/pygame_render/vertex_tone.glsl
+++ b/src/pygame_render/vertex_tone.glsl
@@ -1,0 +1,13 @@
+#version 330 core
+
+layout(location=0)in vec3 vertexPos;
+layout(location=1)in vec2 vertexTexCoord;
+
+out vec3 fragmentColor;
+out vec2 fragmentTexCoord;
+
+void main()
+{
+    gl_Position=vec4(vertexPos,1.);
+    fragmentTexCoord=vertexTexCoord;
+}


### PR DESCRIPTION
Hi,  I added an HDR option as follows:

- Introduced a hdr_render boolean option in the render() method of the Engine class.
- When hdr_render is set to True, it renders HDR textures with tone mapping via a dedicated shader (included in the engine).
- The tone mapping shader supports colors above 1.0 and uses an exposure uniform for adjustment. This exposure value is hardcoded for now but can be modified in the future for finer control. 
- Added example9.py to demonstrate this feature.

