### PR TITLE
Render texts directly 

### DIFF
--- a/examples/example10.py
+++ b/examples/example10.py
@@ -1,0 +1,31 @@
+import sys
+sys.path.insert(0, '/Users/olakenjiforslund/OKF/Leisure/Programming/Python/projects/pygame-render/src/') 
+
+import pygame
+from pygame_render import RenderEngine
+
+pygame.init()
+display_size = (800, 600)
+
+engine = RenderEngine(display_size[0], display_size[1], font_path = None, font_size = 20)
+
+screen = engine.make_layer(display_size)
+text_layer = engine.make_layer((300, 300))
+
+running = True
+time = 0
+while running:
+    screen.clear(0,0,0,255)
+    text_layer.clear(0,0,0,255)
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+
+    time += 0.01
+
+    layer = engine.render_text_alignment(text_layer, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ, abcdefghijklmnopqrstuvwxyz', letter_frame = int(time), colour = (0, 1, 0,1 ), scale = 1)
+    engine.render(layer.texture, screen)
+    engine.render(screen.texture, engine.screen) 
+    pygame.display.flip()
+
+pygame.quit()

--- a/src/pygame_render/engine.py
+++ b/src/pygame_render/engine.py
@@ -26,7 +26,8 @@ class RenderEngine:
     def __init__(self, screen_width: int, screen_height: int,
                  fullscreen: int | bool = 0, resizable: int | bool = 0,
                  noframe: int | bool = 0, scaled: int | bool = 0,
-                 depth: int = 0, display: int = 0, vsync: int = 0) -> None:
+                 depth: int = 0, display: int = 0, vsync: int = 0,
+                 font_path: str = None, font_size: int = 40) -> None:
         """
         Initialize a rendering engine using Pygame and ModernGL.
 
@@ -125,6 +126,248 @@ class RenderEngine:
             void main() {
             color = primColor;
             }''',)
+
+        # read the tone mapping shader
+        vertex_src = resources.read_text(
+            'pygame_render', 'vertex_text.glsl')
+        fragment_src_draw = resources.read_text(
+            'pygame_render', 'fragment_text.glsl')
+
+        # Create draw shader program
+        prog_draw = self._ctx.program(vertex_shader=vertex_src,
+                                      fragment_shader=fragment_src_draw)        
+        self._shader_text = Shader(prog_draw)
+
+        pygame.font.init()
+        self.font_size = font_size
+        self.font = pygame.font.Font(font_path, self.font_size) # Preload font
+
+        self.char_uvs = {}  # Dictionary to store character textures
+        self.char_sizes = {}
+        self._generate_font_atlas()                  
+
+    def _generate_font_atlas(self):
+        padding = 4 #Padding to avoid "bleeding"
+
+        #Font metrics
+        ascent = self.font.get_ascent()
+        descent = self.font.get_descent()
+        max_height = ascent + abs(descent)
+        max_width = self.font.size("M")[0]  # Widest likely char
+
+        cell_w = max_width + padding * 2
+        cell_h = max_height + padding * 2
+
+        cols = 16
+        rows = ((127 - 32) + cols - 1) // cols
+
+        atlas_width = cols * cell_w
+        atlas_height = rows * cell_h
+
+        atlas_surface = pygame.Surface((atlas_width, atlas_height), pygame.SRCALPHA, 32).convert_alpha()
+        atlas_surface.fill((0, 0, 0, 0))
+
+        for i, char_code in enumerate(range(32, 127)):
+            char = chr(char_code)
+            rendered_char = self.font.render(char, True, (255, 255, 255))
+            char_w, char_h = rendered_char.get_size()
+
+            col = i % cols
+            row = i // cols
+
+            # Blit with proper vertical offset using ascent to preserve tops
+            x = col * cell_w + padding
+            y = row * cell_h + padding + (ascent - self.font.get_ascent())
+
+            atlas_surface.blit(rendered_char, (x, y))
+
+            # Shrink UVs slightly to avoid bleeding
+            u1 = (col * cell_w + padding + 0.5) / atlas_width
+            v1 = 1 - (row * cell_h + padding + 0.5) / atlas_height
+            u2 = (col * cell_w + padding + char_w - 0.5) / atlas_width
+            v2 = 1 - (row * cell_h + padding + char_h - 0.5) / atlas_height
+
+            self.char_uvs[char] = (u1, v1, u2, v2)
+            self.char_sizes[char] = (char_w, char_h)
+
+        self.font_texture = self.surface_to_texture(atlas_surface)
+
+    def render_text(self, layer, text: str, letter_frame: int, colour: tuple = (1.0, 1.0, 1.0, 1.0), scale: float = 1.0):
+        """
+        Render the text on the specified layer with an optional color.
+        
+        Parameters:
+        - layer: The rendering layer to draw on.
+        - text: The text to render.
+        - letter_frame: The number of letters to render (useful for animations).
+        - color: The color of the text as an RGBA tuple. Default is white (1.0, 1.0, 1.0, 1.0).
+        - scale: Multiplier for glyph size (1.0 = original size).
+        """
+        text = text[:letter_frame + 1]
+
+        layer_width = layer.width
+        layer_height = layer.height
+
+        x, y = -1.0, 1.0  #Start at the top-left corner
+        line_width = 0  #Track width of the current line
+        line_height = 0  #Track the maximum height of the current line
+
+        vertices = []
+        tex_coords = []
+
+        for char in text:
+            if char in self.char_uvs and char in self.char_sizes:
+                uv = self.char_uvs[char]
+                char_w, char_h = self.char_sizes[char]  # Use true width from font rendering
+
+                # Convert pixel size to OpenGL normalized space (-1 to 1)
+                w = (char_w / layer_width) * 2 * scale
+                h = (char_h / layer_height) * 2 * scale
+
+                # Check if adding this character would exceed the width of the layer
+                if line_width + w > 2.0:  # If line exceeds the width
+                    # Move to the next line
+                    x = -1.0  # Reset x to the start of the line
+                    y -= line_height  # Move y down by the height of the current line
+                    line_width = 0  # Reset line width
+                    line_height = 0  # Reset line height
+                    w = 0#skip space if new row
+
+                # Define quad vertices (adjusted for OpenGL top-left origin)
+                vertices.extend([
+                    x, y - h, uv[0], uv[3],  
+                    x + w, y - h, uv[2], uv[3],  
+                    x, y, uv[0], uv[1],  
+
+                    x, y, uv[0], uv[1],  
+                    x + w, y - h, uv[2], uv[3],  
+                    x + w, y, uv[2], uv[1]  
+                ])
+                tex_coords.extend([uv[0], uv[1], uv[2], uv[1], uv[0], uv[3], uv[0], uv[3], uv[2], uv[1], uv[2], uv[3]])
+
+                # Update the current line's width and height
+                line_width += w
+                line_height = max(line_height, h)
+                
+                x += w#Move x to the next character's position
+
+        vertices = np.array(vertices, dtype=np.float32)
+        tex_coords = np.array(tex_coords, dtype=np.float32)
+
+        self.render_batch(layer, vertices, tex_coords, colour)
+
+        return layer
+
+    def render_text_alignment(self, layer, text: str, letter_frame: int, colour: tuple = (1.0, 1.0, 1.0, 1.0), scale: float = 1.0, alignment: str = "left"):#same as render_text but supports alignment. Is allignment needed?
+        """
+        Render the text on the specified layer with an optional color.
+        
+        Parameters:
+        - layer: The rendering layer to draw on.
+        - text: The text to render.
+        - letter_frame: The number of letters to render (useful for animations).
+        - color: The color of the text as an RGBA tuple. Default is white (1.0, 1.0, 1.0, 1.0).
+        - scale: Multiplier for glyph size (1.0 = original size).
+        - alignment: The alignment of the text, acceptes left, center and right
+        """
+        text = text[:letter_frame + 1]
+
+        layer_width = layer.width
+        layer_height = layer.height
+
+        max_width = 2.0  #Normalized OpenGL width (-1 to 1)
+        lines = []
+        current_line = []
+        line_width = 0.0
+        line_height = 0.0
+        max_line_height = 0.0
+
+        # --- Step 1: Break text into lines
+        for char in text:
+            if char in self.char_sizes:
+                char_w, char_h = self.char_sizes[char]
+                w = (char_w / layer_width) * 2 * scale
+                h = (char_h / layer_height) * 2* scale
+
+                if line_width + w > max_width:
+                    # Start new line
+                    lines.append((current_line, line_width, max_line_height))
+                    current_line = []
+                    line_width = 0
+                    max_line_height = 0
+
+                current_line.append((char, w, h))
+                line_width += w
+                max_line_height = max(max_line_height, h)
+
+        if current_line:
+            lines.append((current_line, line_width, max_line_height))
+
+        # --- Step 2: Render lines with alignment
+        vertices = []
+        tex_coords = []
+
+        y = 1.0  # Start from top of screen
+
+        for line_chars, line_width, line_height in lines:
+            # Determine starting x based on alignment
+            if alignment == "center":
+                x = -line_width / 2
+            elif alignment == "right":
+                x = 1.0 - line_width
+            else:  # left
+                x = -1.0
+
+            for char, w, h in line_chars:
+                uv = self.char_uvs[char]
+
+                vertices.extend([
+                    x, y - h, uv[0], uv[3],  
+                    x + w, y - h, uv[2], uv[3],  
+                    x, y, uv[0], uv[1],  
+
+                    x, y, uv[0], uv[1],  
+                    x + w, y - h, uv[2], uv[3],  
+                    x + w, y, uv[2], uv[1]  
+                ])
+                tex_coords.extend([uv[0], uv[1], uv[2], uv[1], uv[0], uv[3], uv[0], uv[3], uv[2], uv[1], uv[2], uv[3]])
+
+                x += w  #Move to next char
+
+            y -= line_height  #Move down for next line
+
+        vertices = np.array(vertices, dtype=np.float32)
+        tex_coords = np.array(tex_coords, dtype=np.float32)
+        self.render_batch(layer, vertices, tex_coords, colour)
+
+        return layer
+
+    def render_batch(self, layer, vertices, tex_coords, colour):
+        """
+        Renders a batch of characters using a single draw call and applies a colour.
+        
+        Parameters:
+        - layer: The rendering layer to draw on.
+        - vertices: The vertices for the character quads.
+        - tex_coords: The texture coordinates for the character quads.
+        - colour: The colour to apply to the text as an RGBA tuple.
+        """
+        self.font_texture.use(location=0)#Bind the font texture at location 0
+
+        vbo = self._ctx.buffer(vertices.tobytes())
+        vao = self._ctx.vertex_array(self._shader_text.program, [
+            (vbo, '2f 2f', 'vertexPos', 'vertexTexCoord'),
+        ])
+        
+        self._shader_text.program['textColor'].value = colour#Pass the colour to the shader
+        
+        layer.framebuffer.use()#Bind the framebuffer
+
+        vao.render(mode=self._ctx.TRIANGLES)
+
+        # Cleanup after rendering
+        vbo.release()
+        vao.release()
 
     @property
     def screen(self) -> Layer:

--- a/src/pygame_render/fragment_text.glsl
+++ b/src/pygame_render/fragment_text.glsl
@@ -1,0 +1,12 @@
+#version 330 core
+
+uniform sampler2D fontTexture;
+uniform vec4 textColor;  // The color for the text
+
+in vec2 fragTexCoord;
+out vec4 FragColor;
+
+void main() {
+    vec4 texColor = texture(fontTexture, fragTexCoord);
+    FragColor = texColor * textColor;  // Apply the color to the texture
+}

--- a/src/pygame_render/vertex_text.glsl
+++ b/src/pygame_render/vertex_text.glsl
@@ -1,0 +1,10 @@
+#version 330
+in vec2 vertexPos;         // Vertex positions (screen space)
+in vec2 vertexTexCoord;    // Texture coordinates (UVs)
+
+out vec2 fragTexCoord;     // Pass the texture coordinates to the fragment shader
+
+void main() {
+    gl_Position = vec4(vertexPos.x, vertexPos.y, 0.0, 1.0); // Set the position
+    fragTexCoord = vertexTexCoord; // Pass the texture coordinate
+}


### PR DESCRIPTION
@MarkelZ 
I think I managed to fix the rendering string directly in one render call. It uses the method `render_text` for rendering text with additional layout features, such as alignment, scaling and colour. The font is initialised when the engine is initialised, and font type can be supplied via a .ttf file. 
