### PR TITLE
fix: prevent extra copying of buffer in memory with surface.get_buffer()

### DIFF
--- a/src/pygame_render/engine.py
+++ b/src/pygame_render/engine.py
@@ -220,11 +220,10 @@ class RenderEngine:
             moderngl.Texture: Converted texture.
         """
 
-        img_flip = pygame.transform.flip(sfc, False, True)
-        img_data = pygame.image.tostring(img_flip, "RGBA")
 
-        tex = self._ctx.texture(sfc.get_size(), components=4, data=img_data)
+        tex = self._ctx.texture(sfc.get_size(), components=4, data=pygame.transform.flip(sfc, False, True).get_buffer())
         tex.filter = (moderngl.NEAREST, moderngl.NEAREST)
+        tex.swizzle = "BGRA"
         return tex
 
     def load_texture(self, path: str) -> moderngl.Texture:


### PR DESCRIPTION
Instead of copying the image data with pygame.image.tostring, it gets a copy from the c buffer saving time